### PR TITLE
Logging package is not needed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 numpy
 lxml
-logging

--- a/scripts/SelectData.py
+++ b/scripts/SelectData.py
@@ -16,8 +16,7 @@ Arguments
 import json
 import argparse
 import os
-import sys 
-import logging 
+import sys
 import heapq
 
 #check Python version


### PR DESCRIPTION
Logging package fails to install with pip
```python
File "/tmp/pip-install-k82gu29w/logging/logging/__init__.py", line 618
        raise NotImplementedError, 'emit must be implemented '\
                                 ^
    SyntaxError: invalid syntax
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

I don't know what it does the `logging` package on PyPI but it is not needed because Python includes a `logging` module by default and it is not used on the code anymore.